### PR TITLE
Refactor to_curl and fix tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,11 @@ source "https://rubygems.org"
 
 gemspec
 
+gem 'rake'
+
 group :development, :test do
   gem 'httparty'
   gem 'minitest'
+  gem 'rubocop', require: false
+  gem 'webmock'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,76 @@
+PATH
+  remote: .
+  specs:
+    http_party_curl (0.1.0)
+      httparty
+      logger
+      minitest
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.8.6)
+      public_suffix (>= 2.0.2, < 6.0)
+    ast (2.4.2)
+    bigdecimal (3.1.8)
+    crack (1.0.0)
+      bigdecimal
+      rexml
+    csv (3.3.0)
+    hashdiff (1.0.1)
+    httparty (0.22.0)
+      csv
+      mini_mime (>= 1.0.0)
+      multi_xml (>= 0.5.2)
+    json (2.7.2)
+    language_server-protocol (3.17.0.3)
+    logger (1.6.1)
+    mini_mime (1.1.5)
+    minitest (5.25.1)
+    multi_xml (0.7.1)
+      bigdecimal (~> 3.1)
+    parallel (1.26.3)
+    parser (3.3.5.0)
+      ast (~> 2.4.1)
+      racc
+    public_suffix (5.0.4)
+    racc (1.8.1)
+    rainbow (3.1.1)
+    rake (13.2.1)
+    regexp_parser (2.9.2)
+    rexml (3.3.6)
+      strscan
+    rubocop (1.66.1)
+      json (~> 2.3)
+      language_server-protocol (>= 3.17.0)
+      parallel (~> 1.10)
+      parser (>= 3.3.0.2)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 2.4, < 3.0)
+      rubocop-ast (>= 1.32.2, < 2.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 2.4.0, < 3.0)
+    rubocop-ast (1.32.3)
+      parser (>= 3.3.1.0)
+    ruby-progressbar (1.13.0)
+    strscan (3.1.0)
+    unicode-display_width (2.6.0)
+    webmock (3.23.1)
+      addressable (>= 2.8.0)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
+
+PLATFORMS
+  ruby
+  x86_64-darwin-23
+
+DEPENDENCIES
+  http_party_curl!
+  httparty
+  minitest
+  rake
+  rubocop
+  webmock
+
+BUNDLED WITH
+   2.5.15

--- a/http_party_curl.gemspec
+++ b/http_party_curl.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name          = "http_party_curl"
-  spec.version       = HttpPartyCurl::VERSION
+  spec.version       = "0.1.0"
   spec.authors       = ["TheScubaGeek"]
 
   spec.summary       = "A gem to log HTTParty requests as cURL commands."
@@ -10,14 +10,12 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/thescubageek/http_party_curl"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 2.5.0"
+  spec.required_ruby_version = '>= 3.0.0'
 
-  spec.files         = Dir["lib/**/*.rb"] + ["README.md", "LICENSE.txt"]
+  spec.files         = Dir["lib/**/*", "test/**/*", "README.md", "LICENSE.txt"]
   spec.require_paths = ["lib"]
 
   spec.add_dependency "httparty"
   spec.add_dependency "logger"
-
-  # If you chose minitest as your test framework
-  spec.add_development_dependency "minitest", "~> 5.0"
+  spec.add_dependency "minitest"
 end

--- a/lib/http_party_curl.rb
+++ b/lib/http_party_curl.rb
@@ -3,6 +3,7 @@
 require 'httparty'
 require 'http_party_curl/version'
 require 'logger'
+require 'json'
 
 # Main module for the HttpPartyCurl gem.
 # Provides functionality to log HTTParty requests as cURL commands.
@@ -21,7 +22,7 @@ module HttpPartyCurl
     # Initializes the configuration with default values.
     def initialize
       @curl_logging_enabled = false
-      @logger = Logger.new($stdout)
+      @logger = ::Logger.new($stdout)
     end
   end
 

--- a/lib/http_party_curl/logger.rb
+++ b/lib/http_party_curl/logger.rb
@@ -21,6 +21,7 @@ module HttpPartyCurl
       # Dynamically defines overridden HTTP methods.
       HTTP_METHODS.each do |http_method|
         define_method(http_method) do |uri, options = {}, &block|
+          options ||= {}
           log_curl(http_method, uri, options)
           super(uri, options, &block)
         end
@@ -33,24 +34,67 @@ module HttpPartyCurl
       # @param options [Hash] the request options (headers, body, etc.).
       # @return [String] the generated cURL command.
       def to_curl(method, uri, options = {})
-        curl_headers = options[:headers] || {}
-        curl_body = options[:body]
-        curl_query = options[:query]
-        curl_basic_auth = options[:basic_auth]
-        curl_digest_auth = options[:digest_auth]
+        options ||= {}
+
+        # Prepare the URI and append query parameters if present
+        uri = prepare_uri(uri, options[:query])
+
+        curl_command = initialize_curl_command(method, uri)
+
+        # Add proxy settings if available
+        add_proxy_settings(curl_command)
+
+        # Add headers to the cURL command
+        add_headers(curl_command, options[:headers])
+
+        # Add authentication to the cURL command
+        add_authentication(curl_command, options[:basic_auth], options[:digest_auth])
+
+        # Add body data to the cURL command
+        add_body_data(curl_command, options[:body], options[:headers])
+
+        curl_command.join(" \\\n")
+      end
+
+      private
+
+      # Prepares the full URI, including base_uri and query parameters.
+      #
+      # @param uri [String] the request URI.
+      # @param query [Hash, nil] the query parameters.
+      # @return [String] the full URI with query parameters.
+      def prepare_uri(uri, query)
+        # Ensure base_uri is included if it's a relative path
+        unless uri.start_with?('http')
+          effective_base_uri = self.base_uri || 'http://localhost' #  rubocop:disable Style/RedundantSelf
+          uri = URI.join(effective_base_uri, uri).to_s
+        end
 
         # Append query parameters to URI if present
-        if curl_query
+        if query
           uri = URI(uri)
           existing_query = URI.decode_www_form(uri.query || '')
-          new_query = existing_query + curl_query.to_a
+          new_query = existing_query + query.to_a
           uri.query = URI.encode_www_form(new_query)
           uri = uri.to_s
         end
 
-        curl_command = ["curl -X #{method.to_s.upcase} '#{uri}'"]
+        uri
+      end
 
-        # Add proxy settings to cURL command if present
+      # Initializes the cURL command with the HTTP method and URI.
+      #
+      # @param method [Symbol] the HTTP method.
+      # @param uri [String] the full request URI.
+      # @return [Array<String>] the initial cURL command array.
+      def initialize_curl_command(method, uri)
+        ["curl -X #{method.to_s.upcase} '#{uri}'"]
+      end
+
+      # Adds proxy settings to the cURL command if present.
+      #
+      # @param curl_command [Array<String>] the cURL command array.
+      def add_proxy_settings(curl_command)
         if default_options && default_options.values_at(*PROXY_OPTIONS).any? { |opt| !opt.nil? && !opt.to_s.empty? }
           proxy_parts = []
           if default_options[:http_proxyuser] && default_options[:http_proxypass]
@@ -59,43 +103,62 @@ module HttpPartyCurl
           proxy_parts << "#{default_options[:http_proxyaddr]}:#{default_options[:http_proxyport]}"
           curl_command << "--proxy 'http://#{proxy_parts.join}'"
         end
-
-        # Add headers to cURL command
-        curl_headers.each { |k, v| curl_command << "-H '#{k}: #{v}'" }
-
-        # Add authentication to cURL command
-        if curl_basic_auth
-          curl_command << "-u '#{curl_basic_auth[:username]}:#{curl_basic_auth[:password]}'"
-        elsif curl_digest_auth
-          curl_command << "--digest -u '#{curl_digest_auth[:username]}:#{curl_digest_auth[:password]}'"
-        end
-
-        # Add body data to cURL command
-        unless curl_body.nil?
-          content_type = curl_headers['Content-Type'] || curl_headers['content-type']
-          if content_type == 'application/x-www-form-urlencoded' && curl_body.is_a?(Hash)
-            form_data = URI.encode_www_form(curl_body)
-            curl_command << "-d '#{form_data}'"
-          elsif content_type == 'multipart/form-data' && curl_body.is_a?(Hash)
-            curl_body.each do |key, value|
-              if value.respond_to?(:path) && value.respond_to?(:read)
-                # File upload
-                curl_command << "-F '#{key}=@#{value.path}'"
-              else
-                curl_command << "-F '#{key}=#{value}'"
-              end
-            end
-          else
-            # Default to JSON encoding for hash bodies
-            body_data = curl_body.is_a?(String) ? curl_body : curl_body.to_json
-            curl_command << "-d '#{body_data}'"
-          end
-        end
-
-        curl_command.join(" \\\n")
       end
 
-      private
+      # Adds headers to the cURL command.
+      #
+      # @param curl_command [Array<String>] the cURL command array.
+      # @param headers [Hash, nil] the request headers.
+      def add_headers(curl_command, headers)
+        (headers || {}).each do |k, v|
+          curl_command << "-H '#{k}: #{v}'"
+        end
+      end
+
+      # Adds authentication options to the cURL command.
+      #
+      # @param curl_command [Array<String>] the cURL command array.
+      # @param basic_auth [Hash, nil] the basic authentication credentials.
+      # @param digest_auth [Hash, nil] the digest authentication credentials.
+      def add_authentication(curl_command, basic_auth, digest_auth)
+        if basic_auth
+          curl_command << "-u '#{basic_auth[:username]}:#{basic_auth[:password]}'"
+        elsif digest_auth
+          curl_command << "--digest -u '#{digest_auth[:username]}:#{digest_auth[:password]}'"
+        end
+      end
+
+      # Adds body data to the cURL command.
+      #
+      # @param curl_command [Array<String>] the cURL command array.
+      # @param body [String, Hash, nil] the request body.
+      # @param headers [Hash, nil] the request headers.
+      # rubocop:disable Metrics/CyclomaticComplexity
+      def add_body_data(curl_command, body, headers)
+        return if body.nil?
+
+        headers ||= {}
+        content_type = headers['Content-Type'] || headers['content-type']
+
+        if content_type == 'application/x-www-form-urlencoded' && body.is_a?(Hash)
+          form_data = URI.encode_www_form(body)
+          curl_command << "-d '#{form_data}'"
+        elsif content_type == 'multipart/form-data' && body.is_a?(Hash)
+          body.each do |key, value|
+            if value.respond_to?(:path) && value.respond_to?(:read)
+              # File upload
+              curl_command << "-F '#{key}=@#{value.path}'"
+            else
+              curl_command << "-F '#{key}=#{value}'"
+            end
+          end
+        else
+          # Default to JSON encoding for hash bodies
+          body_data = body.is_a?(String) ? body : body.to_json
+          curl_command << "-d '#{body_data}'"
+        end
+      end
+      # rubocop:enable Metrics/CyclomaticComplexity
 
       # Logs the cURL command for the request if logging is enabled.
       #

--- a/lib/http_party_curl/version.rb
+++ b/lib/http_party_curl/version.rb
@@ -2,5 +2,5 @@
 
 module HttpPartyCurl
   # Gem version number.
-  VERSION = "0.1.0"
+  VERSION = "0.1.0".freeze
 end

--- a/test/http_party_curl/logger_test.rb
+++ b/test/http_party_curl/logger_test.rb
@@ -1,16 +1,20 @@
-# test/http_party_curl_test.rb
+# frozen_string_literal: true
+
+# test/http_party_curl/logger_test.rb
 
 require 'minitest/autorun'
-require 'httparty'
 require 'http_party_curl'
 require 'stringio'
+require 'webmock/minitest'
 
-class HttpPartyCurlTest < Minitest::Test
+class HttpPartyCurl::LoggerTest < Minitest::Test
   def setup
+    @base_uri = 'http://example.com'
+
     # Configure the gem for testing
     HttpPartyCurl.configure do |config|
       config.curl_logging_enabled = true
-      config.logger = Logger.new(StringIO.new) # Use StringIO to capture logger output
+      config.logger = ::Logger.new(StringIO.new) # Use StringIO to capture logger output
     end
 
     # Create a dynamic client class for testing
@@ -20,17 +24,26 @@ class HttpPartyCurlTest < Minitest::Test
 
       base_uri 'http://example.com'
     end
+
+    # Stub all HTTP requests to example.com
+    stub_request(:any, /example\.com/).to_return(status: 200, body: "", headers: {})
+
+    # Disable real network connections
+    WebMock.disable_net_connect!(allow_localhost: true)
   end
 
   def teardown
     # Reset the configuration after each test
     HttpPartyCurl.configuration = HttpPartyCurl::Configuration.new
+
+    # Reset WebMock after each test
+    WebMock.reset!
   end
 
   def test_get_request_logs_curl_command
     mock_logger = Minitest::Mock.new
     mock_logger.expect(:info, nil) do |message|
-      message.include?("curl -X GET 'http://example.com/'")
+      message.include?("curl -X GET '#{@base_uri}/'")
     end
 
     HttpPartyCurl.configuration.logger = mock_logger
@@ -42,10 +55,13 @@ class HttpPartyCurlTest < Minitest::Test
 
   def test_post_request_with_body
     body = { 'key' => 'value' }
-    expected_curl = "curl -X POST 'http://example.com/' \\\n-d '#{body.to_json}'"
+    expected_curl = "curl -X POST '#{@base_uri}/' \\\n-d '#{body.to_json}'"
 
     captured_output = StringIO.new
-    HttpPartyCurl.configuration.logger = Logger.new(captured_output)
+    logger = ::Logger.new(captured_output)
+    # Set a simple formatter to exclude timestamps and severity levels
+    logger.formatter = proc { |severity, datetime, progname, msg| "#{msg}\n" }
+    HttpPartyCurl.configuration.logger = logger
 
     @client_class.post('/', body: body)
 
@@ -57,7 +73,7 @@ class HttpPartyCurlTest < Minitest::Test
     expected_curl = "-H 'Content-Type: application/json' \\\n-H 'Authorization: Bearer token'"
 
     captured_output = StringIO.new
-    HttpPartyCurl.configuration.logger = Logger.new(captured_output)
+    HttpPartyCurl.configuration.logger = ::Logger.new(captured_output)
 
     @client_class.get('/', headers: headers)
 
@@ -66,10 +82,10 @@ class HttpPartyCurlTest < Minitest::Test
 
   def test_request_with_query_params
     query = { 'param1' => 'value1', 'param2' => 'value2' }
-    expected_uri = "http://example.com/?param1=value1&param2=value2"
+    expected_uri = "#{@base_uri}/?param1=value1&param2=value2"
 
     captured_output = StringIO.new
-    HttpPartyCurl.configuration.logger = Logger.new(captured_output)
+    HttpPartyCurl.configuration.logger = ::Logger.new(captured_output)
 
     @client_class.get('/', query: query)
 
@@ -81,7 +97,7 @@ class HttpPartyCurlTest < Minitest::Test
     expected_curl = "-u 'user:pass'"
 
     captured_output = StringIO.new
-    HttpPartyCurl.configuration.logger = Logger.new(captured_output)
+    HttpPartyCurl.configuration.logger = ::Logger.new(captured_output)
 
     @client_class.get('/', basic_auth: auth)
 
@@ -93,7 +109,7 @@ class HttpPartyCurlTest < Minitest::Test
     expected_curl = "--digest -u 'user:pass'"
 
     captured_output = StringIO.new
-    HttpPartyCurl.configuration.logger = Logger.new(captured_output)
+    HttpPartyCurl.configuration.logger = ::Logger.new(captured_output)
 
     @client_class.get('/', digest_auth: auth)
 
@@ -106,7 +122,7 @@ class HttpPartyCurlTest < Minitest::Test
     expected_data = "key1=value1&key2=value2"
 
     captured_output = StringIO.new
-    HttpPartyCurl.configuration.logger = Logger.new(captured_output)
+    HttpPartyCurl.configuration.logger = ::Logger.new(captured_output)
 
     @client_class.post('/', headers: headers, body: body)
 
@@ -119,7 +135,7 @@ class HttpPartyCurlTest < Minitest::Test
     headers = { 'Content-Type' => 'multipart/form-data' }
 
     captured_output = StringIO.new
-    HttpPartyCurl.configuration.logger = Logger.new(captured_output)
+    HttpPartyCurl.configuration.logger = ::Logger.new(captured_output)
 
     @client_class.post('/', headers: headers, body: body)
 
@@ -134,7 +150,7 @@ class HttpPartyCurlTest < Minitest::Test
     expected_proxy = "--proxy 'http://proxyuser:proxypass@proxy.example.com:8080'"
 
     captured_output = StringIO.new
-    HttpPartyCurl.configuration.logger = Logger.new(captured_output)
+    HttpPartyCurl.configuration.logger = ::Logger.new(captured_output)
 
     @client_class.get('/')
 
@@ -144,32 +160,32 @@ class HttpPartyCurlTest < Minitest::Test
   def test_logging_disabled
     HttpPartyCurl.configuration.curl_logging_enabled = false
     mock_logger = Minitest::Mock.new
-    mock_logger.expect(:info, nil).never
 
     HttpPartyCurl.configuration.logger = mock_logger
 
     @client_class.get('/')
 
+    # If logger.info is called, the mock will raise an error
     mock_logger.verify
   end
 
   def test_custom_logger
     captured_output = StringIO.new
-    custom_logger = Logger.new(captured_output)
+    custom_logger = ::Logger.new(captured_output)
 
     HttpPartyCurl.configuration.logger = custom_logger
 
     @client_class.get('/')
 
-    assert_includes captured_output.string, "curl -X GET 'http://example.com/'"
+    assert_includes captured_output.string, "curl -X GET '#{@base_uri}/'"
   end
 
   def test_put_request
     body = { 'update' => 'data' }
-    expected_curl = "curl -X PUT 'http://example.com/' \\\n-d '#{body.to_json}'"
+    expected_curl = "curl -X PUT '#{@base_uri}/' \\\n-d '#{body.to_json}'"
 
     captured_output = StringIO.new
-    HttpPartyCurl.configuration.logger = Logger.new(captured_output)
+    HttpPartyCurl.configuration.logger = ::Logger.new(captured_output)
 
     @client_class.put('/', body: body)
 
@@ -178,10 +194,10 @@ class HttpPartyCurlTest < Minitest::Test
 
   def test_patch_request
     body = { 'patch' => 'data' }
-    expected_curl = "curl -X PATCH 'http://example.com/' \\\n-d '#{body.to_json}'"
+    expected_curl = "curl -X PATCH '#{@base_uri}/' \\\n-d '#{body.to_json}'"
 
     captured_output = StringIO.new
-    HttpPartyCurl.configuration.logger = Logger.new(captured_output)
+    HttpPartyCurl.configuration.logger = ::Logger.new(captured_output)
 
     @client_class.patch('/', body: body)
 
@@ -189,10 +205,10 @@ class HttpPartyCurlTest < Minitest::Test
   end
 
   def test_delete_request
-    expected_curl = "curl -X DELETE 'http://example.com/'"
+    expected_curl = "curl -X DELETE '#{@base_uri}/'"
 
     captured_output = StringIO.new
-    HttpPartyCurl.configuration.logger = Logger.new(captured_output)
+    HttpPartyCurl.configuration.logger = ::Logger.new(captured_output)
 
     @client_class.delete('/')
 
@@ -204,7 +220,7 @@ class HttpPartyCurlTest < Minitest::Test
     expected_curl = "-d '#{body}'"
 
     captured_output = StringIO.new
-    HttpPartyCurl.configuration.logger = Logger.new(captured_output)
+    HttpPartyCurl.configuration.logger = ::Logger.new(captured_output)
 
     @client_class.post('/', body: body)
 
@@ -217,7 +233,7 @@ class HttpPartyCurlTest < Minitest::Test
     expected_curl_accept = "-H 'ACCEPT: application/json'"
 
     captured_output = StringIO.new
-    HttpPartyCurl.configuration.logger = Logger.new(captured_output)
+    HttpPartyCurl.configuration.logger = ::Logger.new(captured_output)
 
     @client_class.get('/', headers: headers)
 
@@ -226,10 +242,10 @@ class HttpPartyCurlTest < Minitest::Test
   end
 
   def test_handles_nil_options
-    expected_curl = "curl -X GET 'http://example.com/'"
+    expected_curl = "curl -X GET '#{@base_uri}/'"
 
     captured_output = StringIO.new
-    HttpPartyCurl.configuration.logger = Logger.new(captured_output)
+    HttpPartyCurl.configuration.logger = ::Logger.new(captured_output)
 
     @client_class.get('/', nil)
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,3 +4,6 @@ $LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "http_party_curl"
 
 require "minitest/autorun"
+
+require 'webmock/minitest'
+WebMock.disable_net_connect!


### PR DESCRIPTION
- Adds rubocop and webmock
- Refactors `to_curl` to be DRYer and easier to test
- Resolves issue with HTTParty included inside HTTPartyCurl module
- Fixes failing tests